### PR TITLE
Allow binaries to be pulled from other repos

### DIFF
--- a/.github/workflows/mod-bundler.yml
+++ b/.github/workflows/mod-bundler.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: "patch"
         type: "string"
+      toolingRepo:
+        description: "The repository from which the tooling is taken for the bundle. Defaults to open-goal/jak-project."
+        required: false
+        default: "open-goal/jak-project"
+        type: "string"
       toolingVersion:
         description: "The version of `jak-project` to bundle. Defaults to latest version."
         required: false
@@ -173,6 +178,7 @@ jobs:
         env:
           outputDir: ${{ inputs.outputDir }}
           versionName: ${{ needs.create-release.outputs.bundleTagName }}
+          toolingRepo: ${{ inputs.toolingRepo }}
           toolingVersion: ${{ inputs.toolingVersion }}
           toolingBinaryDir: ${{ inputs.toolingBinaryDir }}
           copyEntireBinaryDir: ${{ inputs.copyEntireBinaryDir }}
@@ -213,6 +219,7 @@ jobs:
         env:
           outputDir: ${{ inputs.outputDir }}
           versionName: ${{ needs.create-release.outputs.bundleTagName }}
+          toolingRepo: ${{ inputs.toolingRepo }}
           toolingVersion: ${{ inputs.toolingVersion }}
           toolingBinaryDir: ${{ inputs.toolingBinaryDir }}
           copyEntireBinaryDir: ${{ inputs.copyEntireBinaryDir }}
@@ -253,6 +260,7 @@ jobs:
         env:
           outputDir: ${{ inputs.outputDir }}
           versionName: ${{ needs.create-release.outputs.bundleTagName }}
+          toolingRepo: ${{ inputs.toolingRepo }}
           toolingVersion: ${{ inputs.toolingVersion }}
           toolingBinaryDir: ${{ inputs.toolingBinaryDir }}
           copyEntireBinaryDir: ${{ inputs.copyEntireBinaryDir }}

--- a/scripts/mod-bundler/bundle-linux.py
+++ b/scripts/mod-bundler/bundle-linux.py
@@ -8,6 +8,7 @@ import tarfile
 args = {
     "outputDir": os.getenv("outputDir"),
     "versionName": os.getenv("versionName"),
+    "toolingRepo": os.getenv("toolingRepo"),
     "toolingVersion": os.getenv("toolingVersion"),
     "toolingBinaryDir": os.getenv("toolingBinaryDir"),
     "copyEntireBinaryDir": os.getenv("copyEntireBinaryDir"),
@@ -32,15 +33,14 @@ if os.path.exists(os.path.join(args["outputDir"], "linux")):
 os.makedirs(os.path.join(args["outputDir"], "linux"), exist_ok=True)
 
 # Download the Release
+toolingRepo = args["toolingRepo"]
 toolingVersion = args["toolingVersion"]
 if toolingVersion == "latest":
-    # Get the latest open-goal/jak-project release
+    # Get the latest release
     toolingVersion = requests.get(
-        "https://api.github.com/repos/open-goal/jak-project/releases/latest"
+        f"https://api.github.com/repos/{toolingRepo}/releases/latest"
     ).json()["tag_name"]
-releaseAssetUrl = "https://github.com/open-goal/jak-project/releases/download/{}/opengoal-linux-{}.tar.gz".format(
-    toolingVersion, toolingVersion
-)
+releaseAssetUrl = f"https://github.com/{toolingRepo}/releases/download/{toolingVersion}/opengoal-linux-{toolingVersion}.tar.gz"
 urllib.request.urlretrieve(
     releaseAssetUrl, os.path.join(args["outputDir"], "linux", "release.tar.gz")
 )

--- a/scripts/mod-bundler/bundle-macos.py
+++ b/scripts/mod-bundler/bundle-macos.py
@@ -8,6 +8,7 @@ import tarfile
 args = {
     "outputDir": os.getenv("outputDir"),
     "versionName": os.getenv("versionName"),
+    "toolingRepo": os.getenv("toolingRepo"),
     "toolingVersion": os.getenv("toolingVersion"),
     "toolingBinaryDir": os.getenv("toolingBinaryDir"),
     "copyEntireBinaryDir": os.getenv("copyEntireBinaryDir"),
@@ -32,15 +33,14 @@ if os.path.exists(os.path.join(args["outputDir"], "macos-intel")):
 os.makedirs(os.path.join(args["outputDir"], "macos-intel"), exist_ok=True)
 
 # Download the Release
+toolingRepo = args["toolingRepo"]
 toolingVersion = args["toolingVersion"]
 if toolingVersion == "latest":
-    # Get the latest open-goal/jak-project release
+    # Get the latest release
     toolingVersion = requests.get(
-        "https://api.github.com/repos/open-goal/jak-project/releases/latest"
+        f"https://api.github.com/repos/{toolingRepo}/releases/latest"
     ).json()["tag_name"]
-releaseAssetUrl = "https://github.com/open-goal/jak-project/releases/download/{}/opengoal-macos-intel-{}.tar.gz".format(
-    toolingVersion, toolingVersion
-)
+releaseAssetUrl = f"https://github.com/{toolingRepo}/releases/download/{toolingVersion}/opengoal-macos-intel-{toolingVersion}.tar.gz"
 urllib.request.urlretrieve(
     releaseAssetUrl, os.path.join(args["outputDir"], "macos-intel", "release.tar.gz")
 )

--- a/scripts/mod-bundler/bundle-windows.py
+++ b/scripts/mod-bundler/bundle-windows.py
@@ -8,6 +8,7 @@ import datetime
 args = {
     "outputDir": os.getenv("outputDir"),
     "versionName": os.getenv("versionName"),
+    "toolingRepo": os.getenv("toolingRepo"),
     "toolingVersion": os.getenv("toolingVersion"),
     "toolingBinaryDir": os.getenv("toolingBinaryDir"),
     "copyEntireBinaryDir": os.getenv("copyEntireBinaryDir"),
@@ -32,15 +33,14 @@ if os.path.exists(os.path.join(args["outputDir"], "windows")):
 os.makedirs(os.path.join(args["outputDir"], "windows"), exist_ok=True)
 
 # Download the Release
+toolingRepo = args["toolingRepo"]
 toolingVersion = args["toolingVersion"]
 if toolingVersion == "latest":
-    # Get the latest open-goal/jak-project release
+    # Get the latest release
     toolingVersion = requests.get(
-        "https://api.github.com/repos/open-goal/jak-project/releases/latest"
+        f"https://api.github.com/repos/{toolingRepo}/releases/latest"
     ).json()["tag_name"]
-releaseAssetUrl = "https://github.com/open-goal/jak-project/releases/download/{}/opengoal-windows-{}.zip".format(
-    toolingVersion, toolingVersion
-)
+releaseAssetUrl = f"https://github.com/{toolingRepo}/releases/download/{toolingVersion}/opengoal-windows-{toolingVersion}.zip"
 urllib.request.urlretrieve(
     releaseAssetUrl, os.path.join(args["outputDir"], "windows", "release.zip")
 )


### PR DESCRIPTION
Some mods need special binaries (such as from https://github.com/OpenGOAL-Mods/OG-Mod-Base). This allows them to be bundled with the latest version without needing to manually update their local binary directory.